### PR TITLE
Added create public_token endpoint

### DIFF
--- a/Plaid API Endpoints Collection.json
+++ b/Plaid API Endpoints Collection.json
@@ -484,6 +484,37 @@
 							]
 						},
 						{
+							"name": "Create a Public Token",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"client_id\": \"{{client_id}}\",\n    \"secret\": \"{{secret_key}}\",\n    \"access_token\": \"ENTER_ACCESS_TOKEN_HERE\"\n}"
+								},
+								"url": {
+									"raw": "https://{{env_url}}/item/public_token/create",
+									"protocol": "https",
+									"host": [
+										"{{env_url}}"
+									],
+									"path": [
+										"item",
+										"public_token",
+										"create"
+									]
+								},
+								"description": "Over time, Items may need to refresh authentication information. This can happen if the user changes a password, if MFA requirements change, or if the login becomes locked. Link’s update mode makes the reauthentication process secure and painless, generate a `public_token` using this endpoint."
+							},
+							"response": []
+						},
+						{
 							"name": "Rotate Access Token",
 							"request": {
 								"method": "POST",
@@ -530,7 +561,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"client_id\": \"{{client_id}}\",\n    \"secret\": \"{{secret_key}}\",\n    \"access_token\": \"Eaccess-sandbox-3f3181d2-76de-40c2-8f3b-152d2c6726d7\"\n}"
+											"raw": "{\n    \"client_id\": \"{{client_id}}\",\n    \"secret\": \"{{secret_key}}\",\n    \"access_token\": \"access-sandbox-3f3181d2-76de-40c2-8f3b-152d2c6726d7\"\n}"
 										},
 										"url": {
 											"raw": "https://{{env_url}}/item/access_token/invalidate",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Click the "Run with Postman" button below to start testing Plaid Sandbox endpoin
   * **Create Item [Sandbox Only]** - Creates an Item by generating a public token. This endpoint only works in the Sandbox environment. Items can only be created through Plaid Link in the development and production environments.
   * **Exchange Token** - Exchanges a public token for an access token.
   * **Retrieve Item** - Retrieves information about an Item.
-  * **Retrieve an Item's Accounts** - Retrieves all available accounts for an Item.  
+  * **Retrieve an Item's Accounts** - Retrieves all available accounts for an Item. 
+  * **Create a `public_token`** - Generates a `public_token` for an existing Item for use in Plaid Link's [update mode](https://plaid.com/docs/#updating-items-via-link).
   * **Rotate Access Token** - Returns a new access token and invalidates the old one.
   * **Update an Item's Webhook** - Updates an Item's webhook url. 
   * **Simulate ITEM_LOGIN_REQUIRED [Sandbox Only]** - Sets an Item in an ITEM_LOGIN_REQUIRED state. Check our [Errors](https://plaid.com/docs/#errors-overview) section in our docs for more information.


### PR DESCRIPTION
This PR adds the `/item/public_token/crate` endpoint used to create a `public_token` from an existing `access_token` for use in Link update mode.