### PR TITLE
add new endpoints and fix default dates in postman request

### DIFF
--- a/Plaid API Endpoints Collection.json
+++ b/Plaid API Endpoints Collection.json
@@ -4235,7 +4235,7 @@
 			"name": "Liabilities",
 			"item": [
 				{
-					"name": "OK",
+					"name": "Retrieve Liabilities",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -4261,7 +4261,40 @@
 							]
 						}
 					},
-					"response": []
+					"response": [
+						{
+							"name": "Retrieve Liabilities",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"client_id\": \"{{client_id}}\",\n\t\"secret\": \"{{secret_key}}\",\n\t\"access_token\": \"{{access_token}}\"\n}"
+								},
+								"url": {
+									"raw": "https://{{env_url}}/liabilities/get",
+									"protocol": "https",
+									"host": [
+										"{{env_url}}"
+									],
+									"path": [
+										"liabilities",
+										"get"
+									]
+								}
+							},
+							"_postman_previewlanguage": null,
+							"header": null,
+							"cookie": [],
+							"body": "{\n  \"accounts\": [\n    {\n      \"account_id\": \"BxBXxLj1m4HMXBm9WZZmCWVbPjX16EHwv99vp\",\n      \"balances\": {\n        \"available\": 100,\n        \"current\": 110,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": null,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"0000\",\n      \"name\": \"Plaid Checking\",\n      \"official_name\": \"Plaid Gold Standard 0% Interest Checking\",\n      \"subtype\": \"checking\",\n      \"type\": \"depository\"\n    },\n    {\n      \"account_id\": \"dVzbVMLjrxTnLjX4G66XUp5GLklm4oiZy88yK\",\n      \"balances\": {\n        \"available\": null,\n        \"current\": 410,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": 2000,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"3333\",\n      \"name\": \"Plaid Credit Card\",\n      \"official_name\": \"Plaid Diamond 12.5% APR Interest Credit Card\",\n      \"subtype\": \"credit card\",\n      \"type\": \"credit\"\n    },\n    {\n      \"account_id\": \"Pp1Vpkl9w8sajvK6oEEKtr7vZxBnGpf7LxxLE\",\n      \"balances\": {\n        \"available\": null,\n        \"current\": 65262,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": null,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"7777\",\n      \"name\": \"Plaid Student Loan\",\n      \"official_name\": null,\n      \"subtype\": \"student\",\n      \"type\": \"loan\"\n    },\n    {\n      \"account_id\": \"BxBXxLj1m4HMXBm9WZJyUg9XLd4rKEhw8Pb1J\",\n      \"balances\": {\n        \"available\": null,\n        \"current\": 56302.06,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": null,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"8888\",\n      \"name\": \"Plaid Mortgage\",\n      \"official_name\": null,\n      \"subtype\": \"mortgage\",\n      \"type\": \"loan\"\n    }\n  ],\n  \"item\": {\n    \"available_products\": [\n      \"balance\",\n      \"investments\"\n    ],\n    \"billed_products\": [\n      \"assets\",\n      \"auth\",\n      \"identity\",\n      \"liabilities\",\n      \"transactions\"\n    ],\n    \"consent_expiration_time\": null,\n    \"error\": null,\n    \"institution_id\": \"ins_3\",\n    \"item_id\": \"eVBnVMp7zdTJLkRNr33Rs6zr7KNJqBFL9DrE6\",\n    \"update_type\": \"background\",\n    \"webhook\": \"https://www.genericwebhookurl.com/webhook\"\n  },\n  \"liabilities\": {\n    \"credit\": [\n      {\n        \"account_id\": \"dVzbVMLjrxTnLjX4G66XUp5GLklm4oiZy88yK\",\n        \"aprs\": [\n          {\n            \"apr_percentage\": 15.24,\n            \"apr_type\": \"balance_transfer_apr\",\n            \"balance_subject_to_apr\": 1562.32,\n            \"interest_charge_amount\": 130.22\n          },\n          {\n            \"apr_percentage\": 27.95,\n            \"apr_type\": \"cash_apr\",\n            \"balance_subject_to_apr\": 56.22,\n            \"interest_charge_amount\": 14.81\n          },\n          {\n            \"apr_percentage\": 12.5,\n            \"apr_type\": \"purchase_apr\",\n            \"balance_subject_to_apr\": 157.01,\n            \"interest_charge_amount\": 25.66\n          },\n          {\n            \"apr_percentage\": 0,\n            \"apr_type\": \"special\",\n            \"balance_subject_to_apr\": 1000,\n            \"interest_charge_amount\": 0\n          }\n        ],\n        \"is_overdue\": false,\n        \"last_payment_amount\": 168.25,\n        \"last_payment_date\": \"2019-05-22\",\n        \"last_statement_issue_date\": \"2019-05-28\",\n        \"last_statement_balance\": 1708.77,\n        \"minimum_payment_amount\": 20,\n        \"next_payment_due_date\": \"2020-05-28\"\n      }\n    ],\n    \"mortgage\": [\n      {\n        \"account_id\": \"BxBXxLj1m4HMXBm9WZJyUg9XLd4rKEhw8Pb1J\",\n        \"account_number\": \"3120194154\",\n        \"current_late_fee\": 25,\n        \"escrow_balance\": 3141.54,\n        \"has_pmi\": true,\n        \"has_prepayment_penalty\": true,\n        \"interest_rate\": {\n          \"percentage\": 3.99,\n          \"type\": \"fixed\"\n        },\n        \"last_payment_amount\": 3141.54,\n        \"last_payment_date\": \"2019-08-01\",\n        \"loan_term\": \"30 year\",\n        \"loan_type_description\": \"conventional\",\n        \"maturity_date\": \"2045-07-31\",\n        \"next_monthly_payment\": 3141.54,\n        \"next_payment_due_date\": \"2019-11-15\",\n        \"origination_date\": \"2015-08-01\",\n        \"origination_principal_amount\": 425000,\n        \"past_due_amount\": 2304,\n        \"property_address\": {\n          \"city\": \"Malakoff\",\n          \"country\": \"US\",\n          \"postal_code\": \"14236\",\n          \"region\": \"NY\",\n          \"street\": \"2992 Cameron Road\"\n        },\n        \"ytd_interest_paid\": 12300.4,\n        \"ytd_principal_paid\": 12340.5\n      }\n    ],\n    \"student\": [\n      {\n        \"account_id\": \"Pp1Vpkl9w8sajvK6oEEKtr7vZxBnGpf7LxxLE\",\n        \"account_number\": \"4277075694\",\n        \"disbursement_dates\": [\n          \"2002-08-28\"\n        ],\n        \"expected_payoff_date\": \"2032-07-28\",\n        \"guarantor\": \"DEPT OF ED\",\n        \"interest_rate_percentage\": 5.25,\n        \"is_overdue\": false,\n        \"last_payment_amount\": 138.05,\n        \"last_payment_date\": \"2019-04-22\",\n        \"last_statement_issue_date\": \"2019-04-28\",\n        \"loan_name\": \"Consolidation\",\n        \"loan_status\": {\n          \"end_date\": \"2032-07-28\",\n          \"type\": \"repayment\"\n        },\n        \"minimum_payment_amount\": 25,\n        \"next_payment_due_date\": \"2019-05-28\",\n        \"origination_date\": \"2002-08-28\",\n        \"origination_principal_amount\": 25000,\n        \"outstanding_interest_amount\": 6227.36,\n        \"payment_reference_number\": \"4277075694\",\n        \"pslf_status\": {\n          \"estimated_eligibility_date\": \"2021-01-01\",\n          \"payments_made\": 200,\n          \"payments_remaining\": 160\n        },\n        \"repayment_plan\": {\n          \"description\": \"Standard Repayment\",\n          \"type\": \"standard\"\n        },\n        \"sequence_number\": \"1\",\n        \"servicer_address\": {\n          \"city\": \"San Matias\",\n          \"country\": \"US\",\n          \"postal_code\": \"99415\",\n          \"region\": \"CA\",\n          \"street\": \"123 Relaxation Road\"\n        },\n        \"ytd_interest_paid\": 280.55,\n        \"ytd_principal_paid\": 271.65\n      }\n    ]\n  },\n  \"request_id\": \"dTnnm60WgKGLnKL\"\n}"
+						}
+					]
 				}
 			]
 		},
@@ -4296,7 +4329,41 @@
 							]
 						}
 					},
-					"response": []
+					"response": [
+						{
+							"name": "Retrieve Investments Holdings",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"client_id\": \"{{client_id}}\",\n\t\"secret\": \"{{secret_key}}\",\n\t\"access_token\": \"{{access_token}}\"\n}"
+								},
+								"url": {
+									"raw": "https://{{env_url}}/investments/holdings/get",
+									"protocol": "https",
+									"host": [
+										"{{env_url}}"
+									],
+									"path": [
+										"investments",
+										"holdings",
+										"get"
+									]
+								}
+							},
+							"_postman_previewlanguage": null,
+							"header": null,
+							"cookie": [],
+							"body": "{\n  \"accounts\": [\n    {\n      \"account_id\": \"5Bvpj4QknlhVWk7GygpwfVKdd133GoCxB814g\",\n      \"balances\": {\n        \"available\": 43200,\n        \"current\": 43200,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": null,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"4444\",\n      \"name\": \"Plaid Money Market\",\n      \"official_name\": \"Plaid Platinum Standard 1.85% Interest Money Market\",\n      \"subtype\": \"money market\",\n      \"type\": \"depository\"\n    },\n    {\n      \"account_id\": \"JqMLm4rJwpF6gMPJwBqdh9ZjjPvvpDcb7kDK1\",\n      \"balances\": {\n        \"available\": null,\n        \"current\": 320.76,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": null,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"5555\",\n      \"name\": \"Plaid IRA\",\n      \"official_name\": null,\n      \"subtype\": \"ira\",\n      \"type\": \"investment\"\n    },\n    {\n      \"account_id\": \"k67E4xKvMlhmleEa4pg9hlwGGNnnEeixPolGm\",\n      \"balances\": {\n        \"available\": null,\n        \"current\": 23631.9805,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": null,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"6666\",\n      \"name\": \"Plaid 401k\",\n      \"official_name\": null,\n      \"subtype\": \"401k\",\n      \"type\": \"investment\"\n    }\n  ],\n  \"holdings\": [\n    {\n      \"account_id\": \"JqMLm4rJwpF6gMPJwBqdh9ZjjPvvpDcb7kDK1\",\n      \"cost_basis\": 1,\n      \"institution_price\": 1,\n      \"institution_price_as_of\": \"2021-04-13\",\n      \"institution_value\": 0.01,\n      \"iso_currency_code\": \"USD\",\n      \"quantity\": 0.01,\n      \"security_id\": \"d6ePmbPxgWCWmMVv66q9iPV94n91vMtov5Are\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"account_id\": \"k67E4xKvMlhmleEa4pg9hlwGGNnnEeixPolGm\",\n      \"cost_basis\": 1.5,\n      \"institution_price\": 2.11,\n      \"institution_price_as_of\": null,\n      \"institution_value\": 2.11,\n      \"iso_currency_code\": \"USD\",\n      \"quantity\": 1,\n      \"security_id\": \"KDwjlXj1Rqt58dVvmzRguxJybmyQL8FgeWWAy\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"account_id\": \"k67E4xKvMlhmleEa4pg9hlwGGNnnEeixPolGm\",\n      \"cost_basis\": 10,\n      \"institution_price\": 10.42,\n      \"institution_price_as_of\": null,\n      \"institution_value\": 20.84,\n      \"iso_currency_code\": \"USD\",\n      \"quantity\": 2,\n      \"security_id\": \"NDVQrXQoqzt5v3bAe8qRt4A7mK7wvZCLEBBJk\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"account_id\": \"JqMLm4rJwpF6gMPJwBqdh9ZjjPvvpDcb7kDK1\",\n      \"cost_basis\": 0.01,\n      \"institution_price\": 0.011,\n      \"institution_price_as_of\": null,\n      \"institution_value\": 110,\n      \"iso_currency_code\": \"USD\",\n      \"quantity\": 10000,\n      \"security_id\": \"8E4L9XLl6MudjEpwPAAgivmdZRdBPJuvMPlPb\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"account_id\": \"k67E4xKvMlhmleEa4pg9hlwGGNnnEeixPolGm\",\n      \"cost_basis\": 23,\n      \"institution_price\": 27,\n      \"institution_price_as_of\": null,\n      \"institution_value\": 636.309,\n      \"iso_currency_code\": \"USD\",\n      \"quantity\": 23.567,\n      \"security_id\": \"JDdP7XPMklt5vwPmDN45t3KAoWAPmjtpaW7DP\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"account_id\": \"k67E4xKvMlhmleEa4pg9hlwGGNnnEeixPolGm\",\n      \"cost_basis\": 15,\n      \"institution_price\": 13.73,\n      \"institution_price_as_of\": null,\n      \"institution_value\": 1373.6865,\n      \"iso_currency_code\": \"USD\",\n      \"quantity\": 100.05,\n      \"security_id\": \"nnmo8doZ4lfKNEDe3mPJipLGkaGw3jfPrpxoN\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"account_id\": \"k67E4xKvMlhmleEa4pg9hlwGGNnnEeixPolGm\",\n      \"cost_basis\": 1,\n      \"institution_price\": 1,\n      \"institution_price_as_of\": null,\n      \"institution_value\": 12345.67,\n      \"iso_currency_code\": \"USD\",\n      \"quantity\": 12345.67,\n      \"security_id\": \"d6ePmbPxgWCWmMVv66q9iPV94n91vMtov5Are\",\n      \"unofficial_currency_code\": null\n    }\n  ],\n  \"item\": {\n    \"available_products\": [\n      \"balance\",\n      \"identity\",\n      \"liabilities\",\n      \"transactions\"\n    ],\n    \"billed_products\": [\n      \"assets\",\n      \"auth\",\n      \"investments\"\n    ],\n    \"consent_expiration_time\": null,\n    \"error\": null,\n    \"institution_id\": \"ins_3\",\n    \"item_id\": \"4z9LPae1nRHWy8pvg9jrsgbRP4ZNQvIdbLq7g\",\n    \"update_type\": \"background\",\n    \"webhook\": \"https://www.genericwebhookurl.com/webhook\"\n  },\n  \"request_id\": \"l68wb8zpS0hqmsJ\",\n  \"securities\": [\n    {\n      \"close_price\": 0.011,\n      \"close_price_as_of\": \"2021-04-13\",\n      \"cusip\": null,\n      \"institution_id\": null,\n      \"institution_security_id\": null,\n      \"is_cash_equivalent\": false,\n      \"isin\": null,\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"Nflx Feb 01'18 $355 Call\",\n      \"proxy_security_id\": null,\n      \"security_id\": \"8E4L9XLl6MudjEpwPAAgivmdZRdBPJuvMPlPb\",\n      \"sedol\": null,\n      \"ticker_symbol\": \"NFLX180201C00355000\",\n      \"type\": \"derivative\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"close_price\": 27,\n      \"close_price_as_of\": null,\n      \"cusip\": \"577130834\",\n      \"institution_id\": null,\n      \"institution_security_id\": null,\n      \"is_cash_equivalent\": false,\n      \"isin\": \"US5771308344\",\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"Matthews Pacific Tiger Fund Insti Class\",\n      \"proxy_security_id\": null,\n      \"security_id\": \"JDdP7XPMklt5vwPmDN45t3KAoWAPmjtpaW7DP\",\n      \"sedol\": null,\n      \"ticker_symbol\": \"MIPTX\",\n      \"type\": \"mutual fund\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"close_price\": 2.11,\n      \"close_price_as_of\": null,\n      \"cusip\": \"00448Q201\",\n      \"institution_id\": null,\n      \"institution_security_id\": null,\n      \"is_cash_equivalent\": false,\n      \"isin\": \"US00448Q2012\",\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"Achillion Pharmaceuticals Inc.\",\n      \"proxy_security_id\": null,\n      \"security_id\": \"KDwjlXj1Rqt58dVvmzRguxJybmyQL8FgeWWAy\",\n      \"sedol\": null,\n      \"ticker_symbol\": \"ACHN\",\n      \"type\": \"equity\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"close_price\": 10.42,\n      \"close_price_as_of\": null,\n      \"cusip\": \"258620103\",\n      \"institution_id\": null,\n      \"institution_security_id\": null,\n      \"is_cash_equivalent\": false,\n      \"isin\": \"US2586201038\",\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"DoubleLine Total Return Bond Fund\",\n      \"proxy_security_id\": null,\n      \"security_id\": \"NDVQrXQoqzt5v3bAe8qRt4A7mK7wvZCLEBBJk\",\n      \"sedol\": null,\n      \"ticker_symbol\": \"DBLTX\",\n      \"type\": \"mutual fund\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"close_price\": 1,\n      \"close_price_as_of\": null,\n      \"cusip\": null,\n      \"institution_id\": null,\n      \"institution_security_id\": null,\n      \"is_cash_equivalent\": true,\n      \"isin\": null,\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"U S Dollar\",\n      \"proxy_security_id\": null,\n      \"security_id\": \"d6ePmbPxgWCWmMVv66q9iPV94n91vMtov5Are\",\n      \"sedol\": null,\n      \"ticker_symbol\": \"USD\",\n      \"type\": \"cash\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"close_price\": 13.73,\n      \"close_price_as_of\": null,\n      \"cusip\": null,\n      \"institution_id\": \"ins_3\",\n      \"institution_security_id\": \"NHX105509\",\n      \"is_cash_equivalent\": false,\n      \"isin\": null,\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"NH PORTFOLIO 1055 (FIDELITY INDEX)\",\n      \"proxy_security_id\": null,\n      \"security_id\": \"nnmo8doZ4lfKNEDe3mPJipLGkaGw3jfPrpxoN\",\n      \"sedol\": null,\n      \"ticker_symbol\": \"NHX105509\",\n      \"type\": \"etf\",\n      \"unofficial_currency_code\": null\n    }\n  ]\n}"
+						}
+					]
 				},
 				{
 					"name": "Retrieve Investments Transactions",
@@ -4311,7 +4378,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"client_id\": \"{{client_id}}\",\n  \"secret\": \"{{secret_key}}\",\n  \"access_token\": \"{{access_token}}\",\n  \"start_date\": \"2017-01-01\",\n  \"end_date\": \"2019-06-01\" \n}"
+							"raw": "{\n  \"client_id\": \"{{client_id}}\",\n  \"secret\": \"{{secret_key}}\",\n  \"access_token\": \"{{access_token}}\",\n  \"start_date\": \"2019-01-01\",\n  \"end_date\": \"2021-01-01\" \n}"
 						},
 						"url": {
 							"raw": "https://{{env_url}}/investments/transactions/get",
@@ -4326,7 +4393,41 @@
 							]
 						}
 					},
-					"response": []
+					"response": [
+						{
+							"name": "Retrieve Investments Transactions",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"client_id\": \"{{client_id}}\",\n  \"secret\": \"{{secret_key}}\",\n  \"access_token\": \"{{access_token}}\",\n  \"start_date\": \"2019-01-01\",\n  \"end_date\": \"2021-01-01\" \n}"
+								},
+								"url": {
+									"raw": "https://{{env_url}}/investments/transactions/get",
+									"protocol": "https",
+									"host": [
+										"{{env_url}}"
+									],
+									"path": [
+										"investments",
+										"transactions",
+										"get"
+									]
+								}
+							},
+							"_postman_previewlanguage": null,
+							"header": null,
+							"cookie": [],
+							"body": "{\n  \"accounts\": [\n    {\n      \"account_id\": \"5e66Dl6jNatx3nXPGwZ7UkJed4z6KBcZA4Rbe\",\n      \"balances\": {\n        \"available\": 100,\n        \"current\": 110,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": null,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"0000\",\n      \"name\": \"Plaid Checking\",\n      \"official_name\": \"Plaid Gold Standard 0% Interest Checking\",\n      \"subtype\": \"checking\",\n      \"type\": \"depository\"\n    },\n    {\n      \"account_id\": \"KqZZMoZmBWHJlz7yKaZjHZb78VNpaxfVa7e5z\",\n      \"balances\": {\n        \"available\": null,\n        \"current\": 320.76,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": null,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"5555\",\n      \"name\": \"Plaid IRA\",\n      \"official_name\": null,\n      \"subtype\": \"ira\",\n      \"type\": \"investment\"\n    },\n    {\n      \"account_id\": \"rz99ex9ZQotvnjXdgQLEsR81e3ArPgulVWjGj\",\n      \"balances\": {\n        \"available\": null,\n        \"current\": 23631.9805,\n        \"iso_currency_code\": \"USD\",\n        \"limit\": null,\n        \"unofficial_currency_code\": null\n      },\n      \"mask\": \"6666\",\n      \"name\": \"Plaid 401k\",\n      \"official_name\": null,\n      \"subtype\": \"401k\",\n      \"type\": \"investment\"\n    }\n  ],\n  \"investment_transactions\": [\n    {\n      \"account_id\": \"rz99ex9ZQotvnjXdgQLEsR81e3ArPgulVWjGj\",\n      \"amount\": -8.72,\n      \"cancel_transaction_id\": null,\n      \"date\": \"2020-05-29\",\n      \"fees\": 0,\n      \"investment_transaction_id\": \"oq99Pz97joHQem4BNjXECev1E4B6L6sRzwANW\",\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"INCOME DIV DIVIDEND RECEIVED\",\n      \"price\": 0,\n      \"quantity\": 0,\n      \"security_id\": \"eW4jmnjd6AtjxXVrjmj6SX1dNEdZp3Cy8RnRQ\",\n      \"subtype\": \"dividend\",\n      \"type\": \"cash\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"account_id\": \"rz99ex9ZQotvnjXdgQLEsR81e3ArPgulVWjGj\",\n      \"amount\": -1289.01,\n      \"cancel_transaction_id\": null,\n      \"date\": \"2020-05-28\",\n      \"fees\": 7.99,\n      \"investment_transaction_id\": \"pK99jB9e7mtwjA435GpVuMvmWQKVbVFLWme57\",\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"SELL Matthews Pacific Tiger Fund Insti Class\",\n      \"price\": 27.53,\n      \"quantity\": -47.74104242992852,\n      \"security_id\": \"JDdP7XPMklt5vwPmDN45t3KAoWAPmjtpaW7DP\",\n      \"subtype\": \"sell\",\n      \"type\": \"sell\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"account_id\": \"rz99ex9ZQotvnjXdgQLEsR81e3ArPgulVWjGj\",\n      \"amount\": 7.7,\n      \"cancel_transaction_id\": null,\n      \"date\": \"2020-05-27\",\n      \"fees\": 7.99,\n      \"investment_transaction_id\": \"LKoo1ko93wtreBwM7yQnuQ3P5DNKbKSPRzBNv\",\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"BUY DoubleLine Total Return Bond Fund\",\n      \"price\": 10.42,\n      \"quantity\": 0.7388014749727547,\n      \"security_id\": \"NDVQrXQoqzt5v3bAe8qRt4A7mK7wvZCLEBBJk\",\n      \"subtype\": \"buy\",\n      \"type\": \"buy\",\n      \"unofficial_currency_code\": null\n    }\n  ],\n  \"item\": {\n    \"available_products\": [\n      \"assets\",\n      \"balance\",\n      \"identity\",\n      \"transactions\"\n    ],\n    \"billed_products\": [\n      \"auth\",\n      \"investments\"\n    ],\n    \"consent_expiration_time\": null,\n    \"error\": null,\n    \"institution_id\": \"ins_12\",\n    \"item_id\": \"8Mqq5rqQ7Pcxq9MGDv3JULZ6yzZDLMCwoxGDq\",\n    \"update_type\": \"background\",\n    \"webhook\": \"https://www.genericwebhookurl.com/webhook\"\n  },\n  \"request_id\": \"iv4q3ZlytOOthkv\",\n  \"securities\": [\n    {\n      \"close_price\": 27,\n      \"close_price_as_of\": null,\n      \"cusip\": \"577130834\",\n      \"institution_id\": null,\n      \"institution_security_id\": null,\n      \"is_cash_equivalent\": false,\n      \"isin\": \"US5771308344\",\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"Matthews Pacific Tiger Fund Insti Class\",\n      \"proxy_security_id\": null,\n      \"security_id\": \"JDdP7XPMklt5vwPmDN45t3KAoWAPmjtpaW7DP\",\n      \"sedol\": null,\n      \"ticker_symbol\": \"MIPTX\",\n      \"type\": \"mutual fund\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"close_price\": 10.42,\n      \"close_price_as_of\": null,\n      \"cusip\": \"258620103\",\n      \"institution_id\": null,\n      \"institution_security_id\": null,\n      \"is_cash_equivalent\": false,\n      \"isin\": \"US2586201038\",\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"DoubleLine Total Return Bond Fund\",\n      \"proxy_security_id\": null,\n      \"security_id\": \"NDVQrXQoqzt5v3bAe8qRt4A7mK7wvZCLEBBJk\",\n      \"sedol\": null,\n      \"ticker_symbol\": \"DBLTX\",\n      \"type\": \"mutual fund\",\n      \"unofficial_currency_code\": null\n    },\n    {\n      \"close_price\": 34.73,\n      \"close_price_as_of\": null,\n      \"cusip\": \"84470P109\",\n      \"institution_id\": null,\n      \"institution_security_id\": null,\n      \"is_cash_equivalent\": false,\n      \"isin\": \"US84470P1093\",\n      \"iso_currency_code\": \"USD\",\n      \"name\": \"Southside Bancshares Inc.\",\n      \"proxy_security_id\": null,\n      \"security_id\": \"eW4jmnjd6AtjxXVrjmj6SX1dNEdZp3Cy8RnRQ\",\n      \"sedol\": null,\n      \"ticker_symbol\": \"SBSI\",\n      \"type\": \"equity\",\n      \"unofficial_currency_code\": null\n    }\n  ],\n  \"total_investment_transactions\": 3\n}"
+						}
+					]
 				}
 			],
 			"description": "Endpoints for Plaid's Investments product."
@@ -6386,6 +6487,203 @@
 							],
 							"cookie": [],
 							"body": "{\n \"request_id\": \"mdqfuVxeoza6mhu\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Get a sweep",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"client_id\": \"{{client_id}}\",\n\t\"secret\": \"{{secret_key}}\",\n  \"sweep_id\": \"SWEEP_ID_GOES_HERE\"\n}"
+						},
+						"url": {
+							"raw": "https://{{env_url}}/transfer/sweep/get",
+							"protocol": "https",
+							"host": [
+								"{{env_url}}"
+							],
+							"path": [
+								"transfer",
+								"sweep",
+								"get"
+							]
+						},
+						"description": "Use the `/sandbox/transfer/simulate` endpoint to simulate a transfer event in the Sandbox environment.  Note that while an event will be simulated and will appear when using endpoints such as `/transfer/event/sync` or `/transfer/event/list`, no transactions will actually take place and funds will not move between accounts, even within the Sandbox."
+					},
+					"response": [
+						{
+							"name": "OK",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"client_id\": \"<string>\",\n    \"secret\": \"<string>\",\n    \"transfer_id\": \"<string>\",\n    \"event_type\": \"<string>\",\n    \"failure_reason\": {\n        \"ach_return_code\": \"<string>\",\n        \"description\": \"<string>\"\n    }\n}"
+								},
+								"url": {
+									"raw": "https://{{env_url}}/transfer/sweep/get",
+									"protocol": "https",
+									"host": [
+										"{{env_url}}"
+									],
+									"path": [
+										"transfer",
+										"sweep",
+										"get"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"sweep\": {\n    \"id\": \"d5394a4d-0b04-4a02-9f4a-7ca5c0f52f9d\",\n    \"created\": \"2020-08-06T17:27:15Z\",\n    \"amount\": \"12.34\",\n    \"iso_currency_code\": \"USD\"\n  },\n  \"request_id\": \"saKrIBuEB9qJZno\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Simulate a sweep in Sandbox",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"client_id\": \"{{client_id}}\",\n\t\"secret\": \"{{secret_key}}\"\n}"
+						},
+						"url": {
+							"raw": "https://{{env_url}}/sandbox/transfer/sweep/simulate",
+							"protocol": "https",
+							"host": [
+								"{{env_url}}"
+							],
+							"path": [
+								"sandbox",
+								"transfer",
+								"sweep",
+								"simulate"
+							]
+						},
+						"description": "Use the `/sandbox/transfer/simulate` endpoint to simulate a transfer event in the Sandbox environment.  Note that while an event will be simulated and will appear when using endpoints such as `/transfer/event/sync` or `/transfer/event/list`, no transactions will actually take place and funds will not move between accounts, even within the Sandbox."
+					},
+					"response": [
+						{
+							"name": "OK",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"client_id\": \"<string>\",\n    \"secret\": \"<string>\",\n    \"transfer_id\": \"<string>\",\n    \"event_type\": \"<string>\",\n    \"failure_reason\": {\n        \"ach_return_code\": \"<string>\",\n        \"description\": \"<string>\"\n    }\n}"
+								},
+								"url": {
+									"raw": "https://{{env_url}}/sandbox/transfer/sweep/simulate",
+									"protocol": "https",
+									"host": [
+										"{{env_url}}"
+									],
+									"path": [
+										"sandbox",
+										"transfer",
+										"sweep",
+										"simulate"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"sweep\": {\n    \"id\": \"d5394a4d-0b04-4a02-9f4a-7ca5c0f52f9d\",\n    \"created_at\": \"2020-12-03T07:27:15Z\",\n    \"amount\": \"15.75\",\n    \"iso_currency_code\": \"USD\"\n  },\n  \"request_id\": \"mdqfuVxeoza6mhu\"\n}"
+						}
+					]
+				},
+				{
+					"name": "List transfer sweeps",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \t\"client_id\": \"{{client_id}}\",\n\t  \"secret\": \"{{secret_key}}\",\n    \"start_date\": \"2019-12-06T22:35:49Z\",\n    \"end_date\": \"2019-12-12T22:35:49Z\",\n    \"count\": 5,\n    \"offset\": 0\n}"
+						},
+						"url": {
+							"raw": "https://{{env_url}}/transfer/sweep/list",
+							"protocol": "https",
+							"host": [
+								"{{env_url}}"
+							],
+							"path": [
+								"transfer",
+								"sweep",
+								"list"
+							]
+						},
+						"description": "Use the `/sandbox/transfer/simulate` endpoint to simulate a transfer event in the Sandbox environment.  Note that while an event will be simulated and will appear when using endpoints such as `/transfer/event/sync` or `/transfer/event/list`, no transactions will actually take place and funds will not move between accounts, even within the Sandbox."
+					},
+					"response": [
+						{
+							"name": "OK",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \t\"client_id\": \"{{client_id}}\",\n\t  \"secret\": \"{{secret_key}}\",\n    \"start_date\": \"2020-12-06T22:35:49Z\",\n    \"end_date\": \"2020-12-12T22:35:49Z\",\n    \"count\": 5,\n    \"offset\": 0\n}"
+								},
+								"url": {
+									"raw": "https://{{env_url}}/transfer/sweep/list",
+									"protocol": "https",
+									"host": [
+										"{{env_url}}"
+									],
+									"path": [
+										"transfer",
+										"sweep",
+										"list"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"sweeps\": [\n    {\n      \"id\": \"d5394a4d-0b04-4a02-9f4a-7ca5c0f52f9d\",\n      \"created_at\": \"2020-12-08T17:27:15Z\",\n      \"amount\": \"-12.34\",\n      \"iso_currency_code\": \"USD\"\n    }\n  ],\n  \"request_id\": \"saKrIBuEB9qJZno\"\n}"
 						}
 					]
 				}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For reasons of security and transparency, getting an access token for use with r
 11. Open the web browser Developer Tools (for example, in Chrome, go to View->Developer->Developer Tools), then open the Console tab within Developer tools.
 12. Click the "Link Account" button on link.html to launch Link. The Plaid Link component should launch. Follow the prompts and log into a financial institution. Make sure to use a real username and password, not the Sandbox credentials.
 13. Once the prompts have completed and you have successfully logged in via Link, the Console tab should contain text saying "the public token is:" followed by the value of the public token. Copy the public token value.
-14. Return to Postman and go to API Endpoints -> Item Creation -> Exchange Token, click on the Body tab, and select the public token value -- by default, it is `"{{public_token}}"`. Replace this value with your copied public token from the previous step, then hit Send.
+14. Return to Postman and go to API Endpoints -> Item Creation -> Exchange Token, click on the Body tab, and select the public token value -- by default, it is `{{public_token}}`. Replace this value with your copied public token from the previous step, making sure the token value is inside the quotation marks, then hit Send.
 15. The response will contain an `access_token` suitable for making calls in Production (or Development)! As in the Quickstart, it will be automatically saved for you to use in future requests. You can then follow the same steps as you did in the Quickstart (starting with step 7) to make API requests for real data.
 
 ## Useful Tools


### PR DESCRIPTION
- Adds transfers sweep endpoints
- Adds examples for a couple of endpoints where they were missing, like /liabilities/get
- Updates default date range for investments transactions request